### PR TITLE
Fix index issue for contao5

### DIFF
--- a/contao/dca/tl_theme.php
+++ b/contao/dca/tl_theme.php
@@ -1,15 +1,9 @@
 <?php
 
-array_splice(
-    $GLOBALS['TL_DCA']['tl_theme']['list']['operations'],
-    5, 0,
-    [
-        'blocks' => [
-            'label' => &$GLOBALS['TL_LANG']['tl_theme']['blocks'],
-            'href'  => 'table=tl_block',
-            'icon'  => 'bundles/heimrichhannotblocks/assets/icon.png',
-        ],
-    ]
-);
+$GLOBALS['TL_DCA']['tl_theme']['list']['operations']['blocks'] = [
+    'label' => &$GLOBALS['TL_LANG']['tl_theme']['blocks'],
+    'href'  => 'table=tl_block',
+    'icon'  => 'bundles/heimrichhannotblocks/assets/icon.png',
+];
 
 $GLOBALS['TL_DCA']['tl_theme']['config']['ctable'][] = 'tl_block';


### PR DESCRIPTION
Hello folks,

after installing the bundle to contao 5.6, I get the following error after going to the themes in the backend:

```
TypeError:
Contao\CoreBundle\DataContainer\DataContainerOperationsBuilder::generateOperation(): Argument #1 ($name) must be of type string, int given, called in /var/www/html/vendor/contao/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php on line 91

  at vendor/contao/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php:200
  at Contao\CoreBundle\DataContainer\DataContainerOperationsBuilder->generateOperation()
     (vendor/contao/core-bundle/src/DataContainer/DataContainerOperationsBuilder.php:91)
  at Contao\CoreBundle\DataContainer\DataContainerOperationsBuilder->initializeWithButtons()
     (vendor/contao/core-bundle/contao/classes/DataContainer.php:887)
  at Contao\DataContainer->generateButtons()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:4990)
  at Contao\DC_Table->listView()
     (vendor/contao/core-bundle/contao/drivers/DC_Table.php:465)
  at Contao\DC_Table->showAll()
     (vendor/contao/core-bundle/contao/classes/Backend.php:465)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/contao/controllers/BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:42)
  at require('/var/www/html/public/index.php')
     (public/app.php:13)    
```

Problem is that the index is an int which isn't supported anymore in contao 5 and php 8+.

The PR fixes that.

Bye Defcon0